### PR TITLE
Ensuring that build succeeds with newer versions of libfuse-dev

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,7 @@
 #
 CFLAGS=-Wall -Werror -O3  `pkg-config fuse --cflags` -I. -DVERSION=$(VERSION)
 LDFLAGS=`pkg-config fuse --libs`
+LDLIBS := $(shell pkg-config fuse --libs)
 
 #
 #  Version is only set if building from the top-level directory


### PR DESCRIPTION
See https://bugs.launchpad.net/ubuntu/+source/fuse/+bug/878612
